### PR TITLE
feat(shape): add support for any type

### DIFF
--- a/examples/lib/dynamodb.ts
+++ b/examples/lib/dynamodb.ts
@@ -1,0 +1,123 @@
+import { BillingMode } from '@aws-cdk/aws-dynamodb';
+import cdk = require('@aws-cdk/core');
+import { Duration } from '@aws-cdk/core';
+import { Schedule } from '@aws-cdk/aws-events';
+
+import { any, DynamoDB, integer, Lambda, string, struct, array, Dependency } from 'punchcard';
+
+const app = new cdk.App();
+export default app;
+
+const stack = new cdk.Stack(app, 'invoke-function');
+
+const executorService = new Lambda.ExecutorService({
+  timeout: cdk.Duration.seconds(10)
+});
+
+const table = new DynamoDB.HashTable(stack, 'my-table', {
+  partitionKey: 'id',
+  shape: {
+    id: string(),
+    count: integer({
+      minimum: 0
+    }),
+    name: string(),
+    array: array(string()),
+    struct: struct({
+      key: string()
+    }),
+    any
+  },
+  billingMode: BillingMode.PAY_PER_REQUEST
+});
+
+const sortedTable = new DynamoDB.SortedTable(stack, 'my-table', {
+  partitionKey: 'id',
+  sortKey: 'count',
+  shape: {
+    id: string(),
+    count: integer(),
+    struct: struct({
+      key: string()
+    })
+  },
+  billingMode: BillingMode.PAY_PER_REQUEST
+});
+
+
+// call the incrementer function from another Lambda Function
+executorService.schedule(stack, 'Caller', {
+  depends: Dependency.list(table, sortedTable),
+  schedule: Schedule.rate(Duration.minutes(1)),
+  handle: async (_, [table, sortedTable]) => {
+    await table.get({
+      id: 'id',
+    });
+
+    await table.put({
+      // the item is type-safe and well structured
+      item: {
+        id: 'id',
+        count: 1,
+        name: 'name',
+        any: {
+          a: 'value'
+        },
+        array: ['some', 'values'],
+        struct: {
+          key: 'value'
+        }
+      },
+      // condition expressions are generated with a nice type-safe DSL
+      if: item => item.count.eq(1)
+        .and(item.array.get(0).eq('some'))
+        .and(item.struct.eq({
+          key: 'value'
+        }))
+        .and(item.struct.fields.key.greaterThan('value'))
+        // the any type is casted to a static type before building a condition expression
+        .and(item.any.as(string()).lessThan('value'))
+        .and(item.any.as(integer()).greaterThanOrEqual(1))
+        .and(item.any.as(array(integer())).equals([1]))
+        .and(item.any.as(array(integer())).get(0).lessThanOrEqual(1))
+        .and(item.any.as(struct({
+          key: string()
+        })).eq({
+          key: 'value'
+        }))
+    });
+
+    await table.update({
+      key: {
+        id: 'id',
+      },
+      actions: item => [
+        // set strings
+        item.name.set('name'),
+        // increement/derecment numbers
+        item.count.increment(1),
+        item.count.decrement(1),
+
+        item.struct.set({ // set the entire struct
+          key: 'value'
+        }),
+        item.struct.fields.key.set('value'), // set a field on the struct
+
+        item.array.set(['some', 'values']), // set the entire array
+        item.array.get(1).set('value') // set a specific index
+      ],
+      if: item => DynamoDB.attribute_exists(item.id)
+    });
+
+    // sorted tables can be queried
+    await sortedTable.query({
+      key: {
+        id: 'id',
+        count: DynamoDB.greaterThan(1)
+      },
+      filter: item => item.struct.equals({
+        key: 'value'
+      })
+    });
+  }
+});

--- a/examples/lib/dynamodb.ts
+++ b/examples/lib/dynamodb.ts
@@ -94,7 +94,7 @@ executorService.schedule(stack, 'Caller', {
       actions: item => [
         // set strings
         item.name.set('name'),
-        // increement/derecment numbers
+        // increement/decrement numbers
         item.count.increment(1),
         item.count.decrement(1),
 

--- a/examples/lib/invoke-function.ts
+++ b/examples/lib/invoke-function.ts
@@ -3,7 +3,7 @@ import cdk = require('@aws-cdk/core');
 import { Duration } from '@aws-cdk/core';
 import { Schedule } from '@aws-cdk/aws-events';
 
-import { DynamoDB, integer, Lambda, string, struct } from 'punchcard';
+import { DynamoDB, integer, Lambda, string, struct, any, boolean } from 'punchcard';
 
 const app = new cdk.App();
 export default app;
@@ -20,7 +20,8 @@ const table = new DynamoDB.HashTable(stack, 'my-table', {
     id: string(),
     count: integer({
       minimum: 0
-    })
+    }),
+    anyProperty: any 
   },
   billingMode: BillingMode.PAY_PER_REQUEST
 });
@@ -56,7 +57,10 @@ const incrementer = executorService.spawn(stack, 'Callable', {
       await table.put({
         item: {
           id: request.id,
-          count: 1
+          count: 1,
+          anyProperty: {
+            this: 'property can be any type supported by the AWS.DynamoDB.DocumentClient',
+          }
         },
         if: item => DynamoDB.attribute_not_exists(item.id)
       });

--- a/examples/lib/stream-processing.ts
+++ b/examples/lib/stream-processing.ts
@@ -1,6 +1,6 @@
 import glue = require('@aws-cdk/aws-glue')
 import cdk = require('@aws-cdk/core');
-import { integer, string, struct, SNS, Lambda, DynamoDB, array, timestamp, Dependency } from 'punchcard';
+import { any, integer, string, struct, SNS, Lambda, DynamoDB, array, timestamp, Dependency, optional } from 'punchcard';
 
 import uuid = require('uuid');
 import { Duration } from '@aws-cdk/core';
@@ -22,7 +22,7 @@ const topic = new SNS.Topic(stack, 'Topic', {
   type: struct({
     key: string(),
     count: integer(),
-    timestamp
+    timestamp,
   })
 });
 
@@ -78,7 +78,7 @@ new Lambda.ExecutorService().schedule(stack, 'DummyData', {
       // message is structured and strongly typed (based on our Topic definition above)
       key,
       count: 1,
-      timestamp: new Date()
+      timestamp: new Date(),
     });
   }
 });

--- a/packages/punchcard/lib/shape/index.ts
+++ b/packages/punchcard/lib/shape/index.ts
@@ -1,7 +1,6 @@
 import { Shape } from './shape';
 import { StructFields, StructPath, StructType } from './types';
 
-export * from '../storage/dynamodb/mapper';
 export * from './json';
 export * from './mapper';
 export * from './shape';

--- a/packages/punchcard/lib/shape/mapper/raw.ts
+++ b/packages/punchcard/lib/shape/mapper/raw.ts
@@ -78,7 +78,9 @@ export namespace Raw {
     }
 
     public read<T extends Type<V>, V>(type: T, parsed: any): any {
-      if (type.kind === Kind.Boolean) {
+      if (type.kind === Kind.Any) {
+        return parsed;
+      } else if (type.kind === Kind.Boolean) {
         if (typeof parsed !== 'boolean') {
           Reader.throwError(type.kind, parsed, 'boolean');
         }
@@ -175,7 +177,9 @@ export namespace Raw {
     }
 
     public write<T extends Type<V>, V>(type: T, value: any): any {
-      if (type.kind === Kind.Boolean) {
+      if (type.kind === Kind.Any) {
+        return value;
+      } else if (type.kind === Kind.Boolean) {
         return value;
       } else if (type.kind === Kind.Integer || type.kind === Kind.Number) {
         return value;

--- a/packages/punchcard/lib/shape/types/any.ts
+++ b/packages/punchcard/lib/shape/types/any.ts
@@ -1,0 +1,119 @@
+import { DynamoPath, InferDynamoPathType } from '../../storage/dynamodb/expression/path';
+import { TreeFields } from '../../tree';
+import { InferJsonPathType, JsonPath } from '../json/path';
+import { hashCode as strHashCode } from './hash';
+import { Kind } from './kind';
+import { Type } from './type';
+
+export class AnyType implements Type<any> {
+  public readonly kind: Kind = Kind.Any;
+
+  public validate(value: any): void {
+    // no op
+  }
+
+  public toJsonPath(parent: JsonPath<any>, name: string): JsonPath<any> {
+    throw new Error('Method not implemented.');
+  }
+  public toDynamoPath(parent: DynamoPath, name: string): AnyDynamoPath {
+    return new AnyDynamoPath(parent, name);
+  }
+  public toJsonSchema(): { [key: string]: any; } {
+    return {};
+  }
+  public toGlueType(): { inputString: string; isPrimitive: boolean; } {
+    throw new Error(`any is not supported with Glue`);
+  }
+  public hashCode(value: any): number {
+    return hashCode(value);
+
+    function hashCode(value: any): number {
+      switch (typeof value) {
+        case 'string': return strHashCode(value);
+        case 'boolean': return value ? 1 : 0;
+        case 'number': return value;
+        case 'undefined': return 0;
+        case 'object':
+          if (Array.isArray(value)) {
+            const prime = 31;
+            let result = 1;
+            value.forEach(item => result += prime * result + hashCode(item));
+            return result;
+          } else {
+            const prime = 31;
+            let result = 1;
+            Object.keys(value).forEach(key => {
+              result += prime * result + strHashCode(key);
+              result += prime * result + hashCode(value[key]);
+            });
+            return result;
+          }
+        default:
+          throw new Error(`unsupported value in any type: '${typeof value}'`);
+      }
+    }
+  }
+  public equals(a: any, b: any): boolean {
+    return equals(a, b);
+
+    function equals(a: any, b: any): boolean {
+      const type = typeof a;
+      if (type !== typeof b) {
+        return false;
+      }
+      switch (type) {
+        case 'undefined': return true;
+        case 'string':
+        case 'number':
+        case 'bigint':
+        case 'boolean':
+          return a === b;
+        case 'object':
+          if (Array.isArray(a) && Array.isArray(b)) {
+            if (a.length !== b.length) {
+              return false;
+            }
+            for (let i = 0; i < a.length; i++) {
+              if (!equals(a[i], b[i])) {
+                return false;
+              }
+            }
+            return true;
+          } else if (Array.isArray(a) || Array.isArray(b)) {
+            return false;
+          }
+          const aKeys = Object.keys(a);
+          const bKeys = new Set(Object.keys(b));
+          if (aKeys.length !== bKeys.size) {
+            return false;
+          }
+          for (const k of aKeys) {
+            if (!bKeys.has(k)) {
+              return false;
+            }
+            if (!equals(a[k], b[k])) {
+              return false;
+            }
+          }
+          return true;
+        default:
+            throw new Error(`unsupported value in any type: '${type}'`);
+      }
+    }
+  }
+}
+
+// tslint:disable-next-line: variable-name
+export const any: AnyType = new AnyType();
+
+export class AnyDynamoPath extends DynamoPath {
+  public as<T extends Type<any>>(type: T): InferDynamoPathType<T> {
+    return type.toDynamoPath(this[TreeFields.parent] as DynamoPath, this[TreeFields.name]) as InferDynamoPathType<T>;
+  }
+}
+
+export class AnyJsonPath extends JsonPath<any> {
+  public as<T extends Type<any>>(type: T): InferJsonPathType<T> {
+    return type.toJsonPath(this[TreeFields.parent] as JsonPath<any>, this[TreeFields.name]) as InferJsonPathType<T>;
+  }
+}

--- a/packages/punchcard/lib/shape/types/index.ts
+++ b/packages/punchcard/lib/shape/types/index.ts
@@ -1,3 +1,4 @@
+export * from './any';
 export * from './array';
 export * from './binary';
 export * from './boolean';

--- a/packages/punchcard/lib/shape/types/kind.ts
+++ b/packages/punchcard/lib/shape/types/kind.ts
@@ -1,4 +1,5 @@
 export enum Kind {
+  Any = 'Any',
   Array = 'Array',
   Binary = 'Binary',
   Boolean = 'Boolean',

--- a/packages/punchcard/lib/storage/dynamodb/expression/compiler.ts
+++ b/packages/punchcard/lib/storage/dynamodb/expression/compiler.ts
@@ -1,7 +1,7 @@
 import AWS = require('aws-sdk');
 import { Writer } from '../../../shape/mapper';
 import { Type } from '../../../shape/types';
-import { Dynamo } from '../mapper';
+import * as Dynamo from '../mapper';
 import { CompileContext } from './compile-context';
 
 export class CompileContextImpl implements CompileContext {

--- a/packages/punchcard/lib/storage/dynamodb/index.ts
+++ b/packages/punchcard/lib/storage/dynamodb/index.ts
@@ -2,4 +2,5 @@ export * from './client';
 export * from './expression';
 export * from './key';
 export * from './query';
+export * from './mapper';
 export * from './table';

--- a/packages/punchcard/lib/storage/dynamodb/mapper.ts
+++ b/packages/punchcard/lib/storage/dynamodb/mapper.ts
@@ -1,3 +1,5 @@
+import AWS = require('aws-sdk');
+
 import { RuntimeShape, Shape } from '../../shape/shape';
 
 import {
@@ -20,239 +22,240 @@ import {
 
 // tslint:disable: no-shadowed-variable
 
-export namespace Dynamo {
-  export interface Configuration {
-    readonly validate?: boolean;
-    readonly reader?: IReader<AWS.DynamoDB.AttributeValue>;
-    readonly writer?: IWriter<AWS.DynamoDB.AttributeValue>;
+export interface Configuration {
+  readonly validate?: boolean;
+  readonly reader?: IReader<AWS.DynamoDB.AttributeValue>;
+  readonly writer?: IWriter<AWS.DynamoDB.AttributeValue>;
+}
+
+export function forShape<S extends Shape>(shape: S, configuration?: Configuration): IMapper<RuntimeShape<S>, AWS.DynamoDB.AttributeMap> {
+  return new Mapper(struct(shape), configuration);
+}
+
+export class Mapper<S extends Shape> implements IMapper<RuntimeShape<S>, AWS.DynamoDB.AttributeMap> {
+  private readonly validate: boolean;
+  private readonly reader: IReader<AWS.DynamoDB.AttributeValue>;
+  private readonly writer: IWriter<AWS.DynamoDB.AttributeValue>;
+
+  constructor(private readonly type: StructType<S>, props: Configuration = {}) {
+    this.validate = props.validate === undefined ? false : props.validate;
+    this.reader = props.reader || Reader.instance;
+    this.writer = props.writer || Writer.instance;
   }
 
-  export function forShape<S extends Shape>(shape: S, configuration?: Configuration): IMapper<RuntimeShape<S>, AWS.DynamoDB.AttributeMap> {
-    return new Mapper(struct(shape), configuration);
-  }
-
-  export class Mapper<S extends Shape> implements IMapper<RuntimeShape<S>, AWS.DynamoDB.AttributeMap> {
-    private readonly validate: boolean;
-    private readonly reader: IReader<AWS.DynamoDB.AttributeValue>;
-    private readonly writer: IWriter<AWS.DynamoDB.AttributeValue>;
-
-    constructor(private readonly type: StructType<S>, props: Configuration = {}) {
-      this.validate = props.validate === undefined ? false : props.validate;
-      this.reader = props.reader || Reader.instance;
-      this.writer = props.writer || Writer.instance;
+  public read(map: AWS.DynamoDB.AttributeMap): RuntimeShape<S> {
+    const record: RuntimeShape<S> = this.reader.read(this.type, { M: map });
+    if (this.validate) {
+      this.type.validate(record);
     }
+    return record;
+  }
 
-    public read(map: AWS.DynamoDB.AttributeMap): RuntimeShape<S> {
-      const record: RuntimeShape<S> = this.reader.read(this.type, { M: map });
-      if (this.validate) {
-        this.type.validate(record);
+  public write(record: RuntimeShape<S>): AWS.DynamoDB.AttributeMap {
+    if (this.validate) {
+      this.type.validate(record);
+    }
+    return this.writer.write(this.type, record).M!;
+  }
+}
+
+const setMappings: any = {
+  [Kind.Binary]: { set: 'BS', item: 'B' },
+  [Kind.String]: { set: 'SS', item: 'S' },
+  [Kind.Integer]: { set: 'NS', item: 'N' },
+  [Kind.Number]: { set: 'NS', item: 'N' }
+};
+// TODO: what to do about this?
+// tslint:disable: radix
+export class Reader implements IReader<AWS.DynamoDB.AttributeValue> {
+  public static readonly instance: Reader = new Reader();
+
+  private static throwError(kind: Kind, parsed: any, expected: string) {
+    throw new Error(`expected a AttributeValue with type ${expected} for ${kind}, got ${Object.keys(parsed).join(',')}`);
+  }
+
+  public read<T extends Type<V>, V>(type: T, value: AWS.DynamoDB.AttributeValue): any {
+    if (type.kind === Kind.Any) {
+      return AWS.DynamoDB.Converter.output(value);
+    } else if (type.kind === Kind.Boolean) {
+      if (value.BOOL === undefined) {
+        Reader.throwError(type.kind, value, 'BOOL');
       }
-      return record;
-    }
 
-    public write(record: RuntimeShape<S>): AWS.DynamoDB.AttributeMap {
-      if (this.validate) {
-        this.type.validate(record);
+      return value.BOOL;
+    } else if (type.kind === Kind.Integer) {
+      if (value.N === undefined) {
+        Reader.throwError(type.kind, value, 'N');
       }
-      return this.writer.write(this.type, record).M!;
-    }
-  }
 
-  const setMappings: any = {
-    [Kind.Binary]: { set: 'BS', item: 'B' },
-    [Kind.String]: { set: 'SS', item: 'S' },
-    [Kind.Integer]: { set: 'NS', item: 'N' },
-    [Kind.Number]: { set: 'NS', item: 'N' }
-  };
-  // TODO: what to do about this?
-  // tslint:disable: radix
-  export class Reader implements IReader<AWS.DynamoDB.AttributeValue> {
-    public static readonly instance: Reader = new Reader();
-
-    private static throwError(kind: Kind, parsed: any, expected: string) {
-      throw new Error(`expected a AttributeValue with type ${expected} for ${kind}, got ${Object.keys(parsed).join(',')}`);
-    }
-
-    public read<T extends Type<V>, V>(type: T, value: AWS.DynamoDB.AttributeValue): any {
-      if (type.kind === Kind.Boolean) {
-        if (value.BOOL === undefined) {
-          Reader.throwError(type.kind, value, 'BOOL');
-        }
-
-        return value.BOOL;
-      } else if (type.kind === Kind.Integer) {
-        if (value.N === undefined) {
-          Reader.throwError(type.kind, value, 'N');
-        }
-
-        return parseInt(value.N!);
-      } else if (type.kind === Kind.Number) {
-        if (value.N === undefined) {
-          Reader.throwError(type.kind, value, 'N');
-        }
-        return parseFloat(value.N!);
-      } else if (type.kind === Kind.String) {
-        if (value.S === undefined) {
-          Reader.throwError(type.kind, value, 'S');
-        }
-        return value.S;
-      } else if (type.kind === Kind.Binary) {
-        if (value.B === undefined) {
-          Reader.throwError(type.kind, value, 'B');
-        }
-        if (Buffer.isBuffer(value.B)) {
-          return value.B;
-        } else if (typeof value.B === 'string') {
-          return new Buffer(value.B);
-        } else if (Array.isArray(value.B)) {
-          return new Buffer(value.B);
-        } else {
-          throw new Error(`unexpected type in B attribute, ${typeof value.B}`);
-        }
-      } else if (type.kind === Kind.Timestamp) {
-        if (value.N === undefined) {
-          Reader.throwError(type.kind, value, 'N');
-        }
-        return new Date(parseInt(value.N!));
-      } else if (type.kind === Kind.Optional) {
-        if (value === undefined || value === null || value.NULL) {
-          return undefined;
-        } else {
-          const optional = type as any as OptionalType<any, any>;
-          return this.read(optional.type, value);
-        }
-      } else if (type.kind === Kind.Struct) {
-        if (value.M === undefined) {
-          Reader.throwError(type.kind, value, 'M');
-        }
+      return parseInt(value.N!);
+    } else if (type.kind === Kind.Number) {
+      if (value.N === undefined) {
+        Reader.throwError(type.kind, value, 'N');
+      }
+      return parseFloat(value.N!);
+    } else if (type.kind === Kind.String) {
+      if (value.S === undefined) {
+        Reader.throwError(type.kind, value, 'S');
+      }
+      return value.S;
+    } else if (type.kind === Kind.Binary) {
+      if (value.B === undefined) {
+        Reader.throwError(type.kind, value, 'B');
+      }
+      if (Buffer.isBuffer(value.B)) {
+        return value.B;
+      } else if (typeof value.B === 'string') {
+        return new Buffer(value.B);
+      } else if (Array.isArray(value.B)) {
+        return new Buffer(value.B);
+      } else {
+        throw new Error(`unexpected type in B attribute, ${typeof value.B}`);
+      }
+    } else if (type.kind === Kind.Timestamp) {
+      if (value.N === undefined) {
+        Reader.throwError(type.kind, value, 'N');
+      }
+      return new Date(parseInt(value.N!));
+    } else if (type.kind === Kind.Optional) {
+      if (value === undefined || value === null || value.NULL) {
+        return undefined;
+      } else {
+        const optional = type as any as OptionalType<any, any>;
+        return this.read(optional.type, value);
+      }
+    } else if (type.kind === Kind.Struct) {
+      if (value.M === undefined) {
+        Reader.throwError(type.kind, value, 'M');
+      }
 
 // tslint:disable-next-line: no-shadowed-variable
-        const struct = type as any as StructType<any>;
-        const result: any = {};
-        Object.keys(struct.shape).forEach(name => {
-          const field = struct.shape[name];
-          const v = value.M![name];
-          result[name] = this.read(field, v);
-        });
-        return result;
-      } else if (type.kind === Kind.Array) {
-        if (value.L === undefined) {
-          Reader.throwError(type.kind, value, 'L');
-        }
-
-        const array = type as any as ArrayType<any, any>;
-        const itemType: any = array.itemType;
-        return value.L!.map(p => this.read(itemType, p)) as any;
-      } else if (type.kind === Kind.Set) {
-        const set: any = type as any as SetType<any, any>;
-        const itemType: any = set.itemType;
-        const mapping: {set: string, item: string} = setMappings[set.itemType.kind];
-        if (!mapping) {
-          throw new Error(`dynamodb only supports binary, string or number sets, but got ${set.itemType.kind}`);
-        }
-        if ((value as any)[mapping.set] === undefined) {
-          Reader.throwError(type.kind, value, mapping.set);
-        }
-
-        const typedSet = TypeSet.forType(itemType);
-        (value as any)[mapping.set].forEach((p: any) => {
-          typedSet.add(this.read(itemType, { [mapping.item]: p }));
-        });
-        return typedSet;
-      } else if (type.kind === Kind.Map) {
-        if (value.M === undefined) {
-          Reader.throwError(type.kind, value, 'M');
-        }
-        const map = type as any as MapType<any, any>;
-        const result = {};
-        Object.keys(value.M!).forEach(name => {
-          const v = value.M![name];
-          (result as any)[name] = this.read(map.valueType, v);
-        });
-        return result;
-      } else {
-        throw new Error(`encountered unknown type, ${type.kind}`);
+      const struct = type as any as StructType<any>;
+      const result: any = {};
+      Object.keys(struct.shape).forEach(name => {
+        const field = struct.shape[name];
+        const v = value.M![name];
+        result[name] = this.read(field, v);
+      });
+      return result;
+    } else if (type.kind === Kind.Array) {
+      if (value.L === undefined) {
+        Reader.throwError(type.kind, value, 'L');
       }
-    }
-  }
 
-  export interface WriterConfig {
-    writeNulls?: boolean;
-  }
-  export class Writer implements IWriter<AWS.DynamoDB.AttributeValue> {
-    public static readonly instance: Writer = new Writer();
-
-    private readonly writeNulls: boolean;
-
-    constructor(props: WriterConfig = {}) {
-      this.writeNulls = props.writeNulls === undefined ? false : props.writeNulls;
-    }
-
-    public write<T extends Type<V>, V>(type: T, value: any): AWS.DynamoDB.AttributeValue {
-      if (type.kind === Kind.Boolean) {
-        return { BOOL: value };
-      } else if (type.kind === Kind.Integer || type.kind === Kind.Number) {
-        return { N: value.toString() };
-      } else if (type.kind === Kind.String) {
-        return { S: value };
-      } else if (type.kind === Kind.Binary) {
-        return { B: value };
-      } else if (type.kind === Kind.Timestamp) {
-        return { N: (value as Date).getTime().toString() };
-      } else if (type.kind === Kind.Optional) {
-        if (value === undefined || value === null) {
-          return this.writeNulls ? { NULL: true } : (undefined as any);
-        } else {
-          const optional = type as any as OptionalType<any, any>;
-          return this.write(optional.type, value);
-        }
-      } else if (type.kind === Kind.Struct) {
-        const struct = type as any as StructType<any>;
-        const result = {};
-        Object.keys(struct.shape).forEach(name => {
-          const field = struct.shape[name];
-          const v = value[name];
-          (result as any)[name] = this.write(field, v);
-        });
-        return { M: result };
-
-      } else if (type.kind === Kind.Array) {
-        const array = type as any as ArrayType<any, any>;
-        const itemType: any = array.itemType;
-        return { L: value.map((p: any) => this.write(itemType, p)) };
-      } else if (type.kind === Kind.Set) {
-        const setType = type as any as SetType<any, any>;
-        const setValue: TypeSet<any, any> = value;
-        const itemType: any = setType.itemType;
-        const mapping = setMappings[itemType.kind];
-
-        if (!mapping) {
-          throw new Error(`dynamodb only supports binary, string or number sets, but got ${type.kind}`);
-        }
-
-        const result = [];
-        for (const v of setValue.values()) {
-          const ser: any = this.write(itemType, v);
-          const res = ser[mapping.item];
-          if (!res) {
-            throw new Error(`expected value for ${mapping.item}, but got ${Object.keys(ser).join(',')}`);
-          }
-          result.push(res);
-        }
-
-        return { [mapping.set]: result };
-      } else if (type.kind === Kind.Map) {
-        const map = type as any as MapType<any, any>;
-        const result = {};
-        Object.keys(value).forEach(name => {
-          const v = value[name];
-          (result as any)[name] = this.write(map.valueType, v);
-        });
-        return { M: result };
-      } else {
-        throw new Error(`encountered unknown type, ${type.kind}`);
+      const array = type as any as ArrayType<any, any>;
+      const itemType: any = array.itemType;
+      return value.L!.map(p => this.read(itemType, p)) as any;
+    } else if (type.kind === Kind.Set) {
+      const set: any = type as any as SetType<any, any>;
+      const itemType: any = set.itemType;
+      const mapping: {set: string, item: string} = setMappings[set.itemType.kind];
+      if (!mapping) {
+        throw new Error(`dynamodb only supports binary, string or number sets, but got ${set.itemType.kind}`);
       }
+      if ((value as any)[mapping.set] === undefined) {
+        Reader.throwError(type.kind, value, mapping.set);
+      }
+
+      const typedSet = TypeSet.forType(itemType);
+      (value as any)[mapping.set].forEach((p: any) => {
+        typedSet.add(this.read(itemType, { [mapping.item]: p }));
+      });
+      return typedSet;
+    } else if (type.kind === Kind.Map) {
+      if (value.M === undefined) {
+        Reader.throwError(type.kind, value, 'M');
+      }
+      const map = type as any as MapType<any, any>;
+      const result = {};
+      Object.keys(value.M!).forEach(name => {
+        const v = value.M![name];
+        (result as any)[name] = this.read(map.valueType, v);
+      });
+      return result;
+    } else {
+      throw new Error(`encountered unknown type, ${type.kind}`);
     }
   }
+}
 
+export interface WriterConfig {
+  writeNulls?: boolean;
+}
+export class Writer implements IWriter<AWS.DynamoDB.AttributeValue> {
+  public static readonly instance: Writer = new Writer();
+
+  private readonly writeNulls: boolean;
+
+  constructor(props: WriterConfig = {}) {
+    this.writeNulls = props.writeNulls === undefined ? false : props.writeNulls;
+  }
+
+  public write<T extends Type<V>, V>(type: T, value: any): AWS.DynamoDB.AttributeValue {
+    if (type.kind === Kind.Any) {
+      return AWS.DynamoDB.Converter.input(value);
+    } else if (type.kind === Kind.Boolean) {
+      return { BOOL: value };
+    } else if (type.kind === Kind.Integer || type.kind === Kind.Number) {
+      return { N: value.toString() };
+    } else if (type.kind === Kind.String) {
+      return { S: value };
+    } else if (type.kind === Kind.Binary) {
+      return { B: value };
+    } else if (type.kind === Kind.Timestamp) {
+      return { N: (value as Date).getTime().toString() };
+    } else if (type.kind === Kind.Optional) {
+      if (value === undefined || value === null) {
+        return this.writeNulls ? { NULL: true } : (undefined as any);
+      } else {
+        const optional = type as any as OptionalType<any, any>;
+        return this.write(optional.type, value);
+      }
+    } else if (type.kind === Kind.Struct) {
+      const struct = type as any as StructType<any>;
+      const result = {};
+      Object.keys(struct.shape).forEach(name => {
+        const field = struct.shape[name];
+        const v = value[name];
+        (result as any)[name] = this.write(field, v);
+      });
+      return { M: result };
+
+    } else if (type.kind === Kind.Array) {
+      const array = type as any as ArrayType<any, any>;
+      const itemType: any = array.itemType;
+      return { L: value.map((p: any) => this.write(itemType, p)) };
+    } else if (type.kind === Kind.Set) {
+      const setType = type as any as SetType<any, any>;
+      const setValue: TypeSet<any, any> = value;
+      const itemType: any = setType.itemType;
+      const mapping = setMappings[itemType.kind];
+
+      if (!mapping) {
+        throw new Error(`dynamodb only supports binary, string or number sets, but got ${type.kind}`);
+      }
+
+      const result = [];
+      for (const v of setValue.values()) {
+        const ser: any = this.write(itemType, v);
+        const res = ser[mapping.item];
+        if (!res) {
+          throw new Error(`expected value for ${mapping.item}, but got ${Object.keys(ser).join(',')}`);
+        }
+        result.push(res);
+      }
+
+      return { [mapping.set]: result };
+    } else if (type.kind === Kind.Map) {
+      const map = type as any as MapType<any, any>;
+      const result = {};
+      Object.keys(value).forEach(name => {
+        const v = value[name];
+        (result as any)[name] = this.write(map.valueType, v);
+      });
+      return { M: result };
+    } else {
+      throw new Error(`encountered unknown type, ${type.kind}`);
+    }
+  }
 }

--- a/packages/punchcard/lib/storage/dynamodb/table.ts
+++ b/packages/punchcard/lib/storage/dynamodb/table.ts
@@ -6,11 +6,14 @@ import core = require('@aws-cdk/core');
 
 import { Dependency } from '../../compute';
 import { Cache, Namespace } from '../../compute/assembly';
-import { Dynamo, Mapper, RuntimeShape, Shape, struct } from "../../shape";
+import { Mapper, RuntimeShape, Shape, struct } from "../../shape";
 import { Omit } from '../../utils';
 import { HashTableClient, HashTableClientImpl, SortedTableClient, SortedTableClientImpl, TableClient } from './client';
 import { Facade, toFacade } from './expression/path';
 import { CompositeKey, HashKey, keyType } from './key';
+
+import * as Dynamo from './mapper';
+
 /**
  * Interface for a DynamoDB Table.
  *

--- a/packages/punchcard/test/shape/test.raw-mapper.ts
+++ b/packages/punchcard/test/shape/test.raw-mapper.ts
@@ -1,6 +1,19 @@
 import 'jest';
 // tslint:disable-next-line: max-line-length
-import { array, ArrayTypeConstraints, bigint, binary, BinaryTypeConstraints, boolean, double, float, integer, map, MapTypeConstraints, NumberConstraints, optional, Raw, RuntimeShape, set, SetTypeConstraints, Shape, smallint, string, StringTypeConstraints, struct, timestamp, TimestampFormat, tinyint, Type } from '../../lib';
+import { any, array, ArrayTypeConstraints, bigint, binary, BinaryTypeConstraints, boolean, double, float, integer, map, MapTypeConstraints, NumberConstraints, optional, Raw, RuntimeShape, set, SetTypeConstraints, Shape, smallint, string, StringTypeConstraints, struct, timestamp, TimestampFormat, tinyint, Type } from '../../lib';
+
+it('any should pass through', () => {
+  const mapper = Raw.forType(any);
+  expect(mapper.read({
+    a: {
+      nested: 'value'
+    }
+  })).toEqual({
+    a: {
+      nested: 'value'
+    }
+  });
+});
 
 describe('boolean', () => {
   const mapper = Raw.forType(boolean);

--- a/packages/punchcard/test/shape/test.types.ts
+++ b/packages/punchcard/test/shape/test.types.ts
@@ -1,0 +1,15 @@
+import { any, set } from "../../lib";
+
+it('any.equals should work for all types', () => {
+  expect(any.equals(true, true)).toBe(true);
+  expect(any.equals(true, false)).toBe(false);
+  expect(any.equals('string', 'string')).toBe(true);
+  expect(any.equals('string', 'not the string')).toBe(false);
+  expect(any.equals('string', 1)).toBe(false);
+  expect(any.equals(1, 1)).toBe(true);
+  expect(any.equals(1, 2)).toBe(false);
+  expect(any.equals({a: 'string'}, {a: 'string'})).toBe(true);
+  expect(any.equals({a: 'string'}, {a: 'string', b: 'string'})).toBe(false);
+  expect(any.equals(['a', 'b'], ['a', 'b'])).toBe(true);
+  expect(any.equals(['a', 'b'], ['a'])).toBe(false);
+});

--- a/packages/punchcard/test/storage/dynamodb/test.client.ts
+++ b/packages/punchcard/test/storage/dynamodb/test.client.ts
@@ -29,7 +29,7 @@ describe('HashTable', () => {
     };
     const table = makeTable({
       key: string(),
-      value: string()
+      value: string(),
     }, 'key', mock as any);
 
     const result = await table.get({

--- a/packages/punchcard/test/storage/dynamodb/test.condition_expression.ts
+++ b/packages/punchcard/test/storage/dynamodb/test.condition_expression.ts
@@ -1,6 +1,7 @@
 import 'jest';
 
 import {
+  any,
   array,
   binary,
   boolean,
@@ -29,6 +30,7 @@ const toFacade = DynamoDB.toFacade;
  * TODO: Tests for optional attributes
  */
 const table = {
+  anyAttribute: any,
   stringAttribute: string(),
   intAttribute: integer(),
   floatAttribute: float(),
@@ -54,6 +56,20 @@ const facade = toFacade(table);
 describe('condition-expression', () => {
   describe('operand comparator operand', () => {
     describe('=', () => {
+      it('any', () => {
+        expect(facade.anyAttribute.as(boolean).equals(true).render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0 = :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              BOOL: true
+            }
+          }
+        });
+      });
+
       it('boolean', () => {
         expect(facade.boolAttribute.equals(true).render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0 = :0',
@@ -175,6 +191,23 @@ describe('condition-expression', () => {
         });
       });
 
+      it('struct as any', () => {
+        expect(facade.anyAttribute.as(struct({
+          nested_id: integer()
+        })).fields.nested_id.equals(1).render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0.#1 = :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute',
+            '#1': 'nested_id'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              N: '1'
+            }
+          }
+        });
+      });
+
       it ('list', () => {
         expect(facade.list.equals([1]).render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0 = :0',
@@ -238,6 +271,20 @@ describe('condition-expression', () => {
     });
 
     describe('<>', () => {
+      it('any', () => {
+        expect(facade.anyAttribute.as(boolean).notEquals(true).render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0 <> :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              BOOL: true
+            }
+          }
+        });
+      });
+
       it('boolean', () => {
         expect(facade.boolAttribute.ne(true).render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0 <> :0',
@@ -359,6 +406,23 @@ describe('condition-expression', () => {
         });
       });
 
+      it('struct as any', () => {
+        expect(facade.anyAttribute.as(struct({
+          nested_id: integer()
+        })).fields.nested_id.ne(1).render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0.#1 <> :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute',
+            '#1': 'nested_id'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              N: '1'
+            }
+          }
+        });
+      });
+
       it ('list', () => {
         expect(facade.list.ne([1]).render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0 <> :0',
@@ -422,6 +486,20 @@ describe('condition-expression', () => {
     });
 
     describe('>', () => {
+      it('any', () => {
+        expect(facade.anyAttribute.as(string()).greaterThan('test').render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0 > :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              S: 'test'
+            }
+          }
+        });
+      });
+
       it('string', () => {
         expect(facade.stringAttribute.gt('test').render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0 > :0',
@@ -507,6 +585,23 @@ describe('condition-expression', () => {
         });
       });
 
+      it('struct as any', () => {
+        expect(facade.anyAttribute.as(struct({
+          nested_id: integer()
+        })).fields.nested_id.gt(1).render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0.#1 > :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute',
+            '#1': 'nested_id'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              N: '1'
+            }
+          }
+        });
+      });
+
       it ('list item', () => {
         expect(facade.list.get(0).gt(1).render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0[0] > :0',
@@ -538,6 +633,20 @@ describe('condition-expression', () => {
     });
 
     describe('>=', () => {
+      it('any', () => {
+        expect(facade.anyAttribute.as(string()).greaterThanOrEqual('test').render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0 >= :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              S: 'test'
+            }
+          }
+        });
+      });
+
       it('string', () => {
         expect(facade.stringAttribute.gte('test').render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0 >= :0',
@@ -623,6 +732,23 @@ describe('condition-expression', () => {
         });
       });
 
+      it('struct as any', () => {
+        expect(facade.anyAttribute.as(struct({
+          nested_id: integer()
+        })).fields.nested_id.gte(1).render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0.#1 >= :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute',
+            '#1': 'nested_id'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              N: '1'
+            }
+          }
+        });
+      });
+
       it ('list item', () => {
         expect(facade.list.get(0).gte(1).render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0[0] >= :0',
@@ -654,6 +780,20 @@ describe('condition-expression', () => {
     });
 
     describe('<', () => {
+      it('any', () => {
+        expect(facade.anyAttribute.as(string()).lessThan('test').render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0 < :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              S: 'test'
+            }
+          }
+        });
+      });
+
       it('string', () => {
         expect(facade.stringAttribute.lt('test').render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0 < :0',
@@ -739,6 +879,23 @@ describe('condition-expression', () => {
         });
       });
 
+      it('struct as any', () => {
+        expect(facade.anyAttribute.as(struct({
+          nested_id: integer()
+        })).fields.nested_id.lt(1).render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0.#1 < :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute',
+            '#1': 'nested_id'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              N: '1'
+            }
+          }
+        });
+      });
+
       it ('list item', () => {
         expect(facade.list.get(0).lt(1).render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0[0] < :0',
@@ -770,6 +927,20 @@ describe('condition-expression', () => {
     });
 
     describe('<=', () => {
+      it('any', () => {
+        expect(facade.anyAttribute.as(string()).lessThanOrEqual('test').render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0 <= :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              S: 'test'
+            }
+          }
+        });
+      });
+
       it('string', () => {
         expect(facade.stringAttribute.lte('test').render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0 <= :0',
@@ -855,6 +1026,23 @@ describe('condition-expression', () => {
         });
       });
 
+      it('struct as any', () => {
+        expect(facade.anyAttribute.as(struct({
+          nested_id: integer()
+        })).fields.nested_id.lte(1).render(new CompileContextImpl())).toEqual({
+          ConditionExpression: '#0.#1 <= :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute',
+            '#1': 'nested_id'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              N: '1'
+            }
+          }
+        });
+      });
+
       it ('list item', () => {
         expect(facade.list.get(0).lte(1).render(new CompileContextImpl())).toEqual({
           ConditionExpression: '#0[0] <= :0',
@@ -887,6 +1075,19 @@ describe('condition-expression', () => {
   });
 
   describe('operand BETWEEN operand AND operand', () => {
+    it('any', () => {
+      expect(facade.anyAttribute.as(string()).between('a', 'b').render(new CompileContextImpl())).toEqual({
+        ConditionExpression: '#0 BETWEEN :0 AND :1',
+        ExpressionAttributeNames: {
+          '#0': 'anyAttribute'
+        },
+        ExpressionAttributeValues: {
+          ':0': { S: 'a' },
+          ':1': { S: 'b' }
+        }
+      });
+    });
+
     it('string', () => {
       expect(facade.stringAttribute.between('a', 'b').render(new CompileContextImpl())).toEqual({
         ConditionExpression: '#0 BETWEEN :0 AND :1',
@@ -995,6 +1196,20 @@ describe('condition-expression', () => {
   });
 
   describe("operand IN operand (',' operand (, ...) ))", () => {
+    it('string', () => {
+      expect(facade.anyAttribute.as(string()).in('a', 'b', 'c').render(new CompileContextImpl())).toEqual({
+        ConditionExpression: '#0 IN (:0,:1,:2)',
+        ExpressionAttributeNames: {
+          '#0': 'anyAttribute'
+        },
+        ExpressionAttributeValues: {
+          ':0': { S: 'a' },
+          ':1': { S: 'b' },
+          ':2': { S: 'c' }
+        }
+      });
+    });
+
     it('string', () => {
       expect(facade.stringAttribute.in('a', 'b', 'c').render(new CompileContextImpl())).toEqual({
         ConditionExpression: '#0 IN (:0,:1,:2)',
@@ -1131,6 +1346,18 @@ describe('condition-expression', () => {
 
     describe('begins_with', () => {
       it('string', () => {
+        expect(facade.anyAttribute.as(string()).beginsWith('string').render(new CompileContextImpl())).toEqual({
+          ConditionExpression: 'begins_with(#0,:0)',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute'
+          },
+          ExpressionAttributeValues: {
+            ':0': { S: 'string' }
+          }
+        });
+      });
+
+      it('string', () => {
         expect(facade.stringAttribute.beginsWith('string').render(new CompileContextImpl())).toEqual({
           ConditionExpression: 'begins_with(#0,:0)',
           ExpressionAttributeNames: {
@@ -1156,6 +1383,20 @@ describe('condition-expression', () => {
     });
 
     describe('contains', () => {
+      it('any attribute', () => {
+        expect(facade.anyAttribute.as(string()).contains('string').render(new CompileContextImpl())).toEqual({
+          ConditionExpression: 'contains(#0,:0)',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute'
+          },
+          ExpressionAttributeValues: {
+            ':0': {
+              S: 'string'
+            }
+          }
+        });
+      });
+
       it('string attribute', () => {
         expect(facade.stringAttribute.contains('string').render(new CompileContextImpl())).toEqual({
           ConditionExpression: 'contains(#0,:0)',
@@ -1336,5 +1577,4 @@ describe('condition-expression', () => {
         });
     });
   });
-
 });

--- a/packages/punchcard/test/storage/dynamodb/test.mapper.ts
+++ b/packages/punchcard/test/storage/dynamodb/test.mapper.ts
@@ -1,0 +1,90 @@
+import 'jest';
+
+import { any, array, binary, boolean, double, DynamoDB, integer, set, Shape, string, struct } from '../../../lib';
+
+const shape = {
+  any,
+  string: string(),
+  binary: binary(),
+  int: integer(),
+  num: double(),
+  bool: boolean,
+  array: array(string()),
+  set: set(string()),
+  struct: struct({
+    key: string()
+  })
+};
+
+const mapper = DynamoDB.forShape(shape);
+
+const richValue = {
+  any: {
+    some: 'value'
+  },
+  binary: Buffer.from('a buffer'),
+  string: 'a string',
+  int: 1,
+  num: 1.2,
+  bool: true,
+  array: ['some', 'value'],
+  set: new Set(['some', 'values']),
+  struct: {
+    key: 'value'
+  },
+};
+
+const rawValue = {
+  any: {
+    M: {
+      some: {
+        S: 'value'
+      }
+    }
+  },
+  string: {
+    S: 'a string'
+  },
+  binary: {
+    B: Buffer.from('a buffer')
+  },
+  int: {
+    N: '1'
+  },
+  num: {
+    N: '1.2'
+  },
+  bool: {
+    BOOL: true
+  },
+  array: {
+    L: [{
+      S: 'some'
+    }, {
+      S: 'value'
+    }]
+  },
+  set: {
+    SS: ['some', 'values']
+  },
+  struct: {
+    M: {
+      key: {
+        S: 'value'
+      }
+    }
+  }
+};
+
+it('should serialize JS object to AttributeMap', () => {
+  expect(mapper.write(richValue)).toEqual(rawValue);
+});
+
+it('should deserialize AttributeMap to JS object', () => {
+  const v = mapper.read(rawValue);
+  expect({
+    ...v,
+    // Sets are wrapped in a special type, so unwrap it before comparing
+    set: new Set(v.set.values())
+  }).toEqual(richValue);
+});

--- a/packages/punchcard/test/storage/dynamodb/test.update_expression.ts
+++ b/packages/punchcard/test/storage/dynamodb/test.update_expression.ts
@@ -1,6 +1,7 @@
 import 'jest';
 
 import {
+  any,
   array,
   binary,
   boolean,
@@ -19,6 +20,7 @@ import { CompileContextImpl } from '../../../lib/storage/dynamodb/expression/com
  * TODO: Tests for optional attributes
  */
 const table = {
+  anyAttribute: any,
   stringAttribute: string(),
   intAttribute: integer(),
   floatAttribute: float(),
@@ -70,6 +72,18 @@ function render(u: DynamoDB.SetAction<any, any>) {
 describe('update-expression', () => {
   describe('set', () => {
     describe('value', () => {
+      it('any', () => {
+        expect(render(facade.anyAttribute.as(boolean).set(true))).toEqual({
+          UpdateExpression: '#0 = :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute'
+          },
+          ExpressionAttributeValues: {
+            ':0': { BOOL: true }
+          }
+        });
+      });
+
       it('boolean', () => {
         expect(render(facade.boolAttribute.set(true))).toEqual({
           UpdateExpression: '#0 = :0',
@@ -240,6 +254,17 @@ describe('update-expression', () => {
     });
 
     describe('to another attribute', () => {
+      it('any', () => {
+        expect(render(facade.anyAttribute.as(boolean).set(facade.other_boolAttribute))).toEqual({
+          UpdateExpression: '#0 = #1',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute',
+            '#1': 'other_boolAttribute',
+          },
+          ExpressionAttributeValues: {}
+        });
+      });
+
       it('boolean', () => {
         expect(render(facade.boolAttribute.set(facade.other_boolAttribute))).toEqual({
           UpdateExpression: '#0 = #1',
@@ -376,6 +401,19 @@ describe('update-expression', () => {
     });
 
     describe('to another computation', () => {
+      it('any', () => {
+        expect(render(facade.anyAttribute.as(integer()).set(facade.other_intAttribute.plus(1)))).toEqual({
+          UpdateExpression: '#0 = #1 + :0',
+          ExpressionAttributeNames: {
+            '#0': 'anyAttribute',
+            '#1': 'other_intAttribute',
+          },
+          ExpressionAttributeValues: {
+            ':0': { N: '1' }
+          }
+        });
+      });
+
       it('int', () => {
         expect(render(facade.intAttribute.set(facade.other_intAttribute.plus(1)))).toEqual({
           UpdateExpression: '#0 = #1 + :0',


### PR DESCRIPTION
Closes #13 

This PR adds support for an `any` type:
* [x] Serialize to and from JSON
* [x] Serialize to and from DynamoDB Attribute Values
* [x] Cast and build DynamoDB condition expressions
* [x] Cast and build DynamoDB update expressions

Added an example of how to use it with DynamoDB:

To make use of the update and condition expressions, you first cast the `any` attribute to a known type and then use that type to build the expressions. E.g. `item.anyAttribute.as(string()).equals('a string')`. This is a simple approach that maintains type-safety and makes use of the existing utilities.

https://github.com/sam-goodwin/punchcard/blob/4a9215fcf8c4d4bbaa94a5c33f6b7af76a22a8f5/examples/lib/dynamodb.ts#L57-L110